### PR TITLE
Add editor-back-to-indentation.

### DIFF
--- a/src/com/phronemophobic/clobber/modes/clojure.clj
+++ b/src/com/phronemophobic/clobber/modes/clojure.clj
@@ -1617,6 +1617,7 @@
    "C-M-f" #'editor-paredit-forward
    "C-M-b" #'editor-paredit-backward
    "C-a" #'text-mode/editor-move-beginning-of-line
+   "M-m" #'text-mode/editor-back-to-indentation
    "C-u C-d" #'text-mode/editor-delete-char
    "C-d" #'editor-paredit-forward-delete
    "C-e" #'text-mode/editor-move-end-of-line

--- a/src/com/phronemophobic/clobber/modes/markdown.clj
+++ b/src/com/phronemophobic/clobber/modes/markdown.clj
@@ -20,6 +20,7 @@
   { ;; "C-M-x" editor-eval-top-form
 
    "C-a" #'text-mode/editor-move-beginning-of-line
+   "M-m" #'text-mode/editor-back-to-indentation
    "C-d" #'text-mode/editor-delete-char
    "C-e" #'text-mode/editor-move-end-of-line
    "C-f" #'text-mode/editor-forward-char


### PR DESCRIPTION
Implements M-m like in Emacs 😎

https://github.com/user-attachments/assets/036041c1-7ba8-40d1-acd4-88164020e626

