### PR TITLE
Update modifier state on key release using key code

### DIFF
--- a/src/com/phronemophobic/clobber/modes/clojure/ui.clj
+++ b/src/com/phronemophobic/clobber/modes/clojure/ui.clj
@@ -1514,10 +1514,15 @@
                                                ctrl? (conj :ctrl?)))]
                 (find-match key-press))))
            ;; release action
-           [[:update $modifiers (fn [xs] (cond-> (or xs #{})
-                                           (not alt?) (disj :alt)
-                                           (not super?) (disj :super)
-                                           (not ctrl?) (disj :ctrl?)))]])))
+           [[:update $modifiers
+             (fn [xs]
+               (cond-> (or xs #{})
+                 (#{:left_alt :right_alt} (skia/keymap key))
+                 (disj :alt)
+                 (#{:left_super :right_super} (skia/keymap key))
+                 (disj :super)
+                 (#{:left_control :right_control} (skia/keymap key))
+                 (disj :ctrl?)))]])))
      body)))
 
 (defui code-editor [{:keys [editor

--- a/src/com/phronemophobic/clobber/modes/clojure/ui.clj
+++ b/src/com/phronemophobic/clobber/modes/clojure/ui.clj
@@ -1482,7 +1482,7 @@
                       key
                       (let [c (first key)]
                         (if shift?
-                          (get uppercase c)
+                          (get uppercase c c)
                           (Character/toLowerCase c))))
                 key-press (cond-> {:key key}
                             alt?   (assoc :meta? true)

--- a/src/com/phronemophobic/clobber/modes/clojure/ui.clj
+++ b/src/com/phronemophobic/clobber/modes/clojure/ui.clj
@@ -1460,7 +1460,9 @@
                                    :editor editor
                                    :$editor $editor}])])
             (let [c (:key key-press)]
-              (when-not (#{:left_shift :right_shift} c)
+              (when-not (#{:left_shift :right_shift
+                           :left_control :right_control
+                           :left_alt :right_alt} c)
                 (cond-> [[:set $next-bindings nil]]
                   (and (not next-bindings)
                        (char? c)


### PR DESCRIPTION
Hi, I noticed some problems with [`clojure-keymap`](https://github.com/phronmophobic/clobber/blob/main/src/com/phronemophobic/clobber/modes/clojure/ui.clj#L1448).

In summary, I am pretty sure the code dealing with removing the modifier state on key release [here](https://github.com/phronmophobic/clobber/blob/913ab1206dbe02a4c019d74ade9f24a24bdbbb86/src/com/phronemophobic/clobber/modes/clojure/ui.clj#L1518-L1520) is broken for me and is causing issues with certain keybindings.

At first I thought I could just remove the `not` on those lines and that seems to work for me. However, if found that the mods bitmap will contain the mask of the mod being released as well as any that are still down, so it could incorrectly remove a still held down mod key from the state. I think we need to use the actual mod `key` in the key-event.

I could refactor this and make it more efficient if you want, so we're not checking all these sets on every key release, wanted to run it by you first though because I'm not 100% this is the correct approach and wont break anything, though it seems to work for me.

Backstory, in case it's useful:

I found that I was struggling to get the `C-c )` keybinding for `paredit-forward-slurp-sexp` working. It seemed to work roughly half the time. Still not 100% why, but ultimately I came to suspect that the minimal demonstration of the issue could be seen if you do the following key sequence:
1. Press control
2. Press and release any other (non modifier) key
3. Press and release any other (non modifier) key again
4. Release control
If you do this, `:ctrl?` will still be left in the modifier state (it wont be "applied" to the next key, it just messes up the matching process I believe).
